### PR TITLE
fix(wallet):修复force_exit

### DIFF
--- a/biz/wallet.go
+++ b/biz/wallet.go
@@ -867,10 +867,11 @@ func (w *BanWallets) TryUpdateStakePctAmt() {
 		acc, ok := config.Accounts[w.Account]
 		if ok {
 			legalValue := w.TotalLegal(nil, true)
-			if banexg.IsContract(core.Market) && config.Leverage > 1 {
-				// 对于合约市场，百分比开单应基于带杠杆的名义资产价值
-				legalValue *= config.Leverage
-			}
+			// 修复：stake_pct应该基于实际保证金计算，而不是名义价值
+			// 杠杆倍数应该在开仓时考虑，而不是在计算百分比时
+			// if banexg.IsContract(core.Market) && config.Leverage > 1 {
+			//     legalValue *= config.Leverage
+			// }
 			// Round to the nearest tenth place
 			// 四舍五入到十位
 			pctAmt := math.Round(legalValue*config.StakePct/1000) * 10


### PR DESCRIPTION
问题根源：
系统在计算百分比时错误地先乘以了杠杆倍数
这导致需要的资金被放大了15倍
100 USDT × 15 × 20% = 300 USDT，而不是正确的20 USDT

错误信息：
<img width="1178" height="1097" alt="image" src="https://github.com/user-attachments/assets/261db488-493f-4b07-81fa-df307377e00c" />

错误分析：
关于资金不足的问题，这是逻辑问题，首先我们看订单数量的计算流程如下：
基础金额计算 (GetStakeAmount):
如果设置了 stake_pct，优先使用百分比计算：账户总价值 × stake_pct% × 杠杆倍数
否则使用固定的 stake_amount: 100
策略仓位调整:
最终订单金额 = 基础金额 × position_size
100 USDT × 0.11 = 11 USDT
数量计算:
订单数量 = 订单金额 ÷ 当前价格
对于ETH价格约100 USDT的情况：11 ÷ 100 ≈ 0.11

现在账户有100，stake_pct为20，杠杆倍数为15，position_size为1
100*0.2/15*1 = 300，但问题本金只需要20啊，而且这还是仓位调整，仓位调整应该只计算增加的部分

比如现在每个订单本金20，也就是说开仓的时候是只考虑购买20*15=300u的币，然后考虑到每种币的价格，不一定能刚好购买到300u，这个时候真正购买的可能是299.995之类的，怎么会出现306.82933呢？在计算仓位或订单的时候没有考虑本金吗？