### PR TITLE
fix(strat): avoid index out of range in CalcJobPerfs when clusters are empty

### DIFF
--- a/strat/common.go
+++ b/strat/common.go
@@ -678,7 +678,15 @@ func CalcJobPerfs(cfg *config.StratPerfConfig, p *core.PerfSta, perfs []*core.Jo
 	})
 	var maxList = make([]float64, 0, len(groups))
 	for _, gp := range groups {
-		maxList = append(maxList, slices.Max(gp.Items))
+		if len(gp.Items) > 0 {
+			maxList = append(maxList, slices.Max(gp.Items))
+		}
+	}
+	// K-means may yield fewer than 5 non-empty clusters when there are few jobs;
+	// skip updating splits rather than indexing out of range.
+	// 当job较少时K-means可能产生少于5个非空簇，此时跳过更新而不是越界访问
+	if len(maxList) < 4 {
+		return
 	}
 	// Calculate the upper and lower bounds of the rate of return for each group
 	// 计算每组的收益率上下界

--- a/strat/perf_calc_test.go
+++ b/strat/perf_calc_test.go
@@ -1,0 +1,21 @@
+package strat
+
+import (
+	"testing"
+
+	"github.com/banbox/banbot/config"
+	"github.com/banbox/banbot/core"
+)
+
+func TestCalcJobPerfsFewJobs(t *testing.T) {
+	cfg := &config.StratPerfConfig{BadWeight: 0.1, MidWeight: 0.5}
+	p := &core.PerfSta{}
+	perfs := []*core.JobPerf{
+		{TotProfit: 1.5},
+		{TotProfit: -0.5},
+	}
+	CalcJobPerfs(cfg, p, perfs)
+	if p.Splits != nil {
+		t.Fatalf("expected Splits to stay nil when clusters < 4, got %v", *p.Splits)
+	}
+}


### PR DESCRIPTION
## **User description**
Fixes #140.

`CalcJobPerfs` assumed `KMeansVals` always returns 5 non-empty clusters, so `slices.Max` on an empty group and the `maxList[0..3]` access panic with "index out of range" when there are only a few jobs (e.g. 2 pairs). This skips empty groups and returns early when fewer than 4 clusters exist, leaving splits unchanged instead of panicking. Added a regression test covering the two-job case.


___

## **CodeAnt-AI Description**
**Avoid crashing when job performance clustering has too few groups**

### What Changed
- Skips updating performance splits when there are fewer than 4 non-empty clusters, so small job sets no longer trigger an out-of-range crash
- Ignores empty clusters before choosing split points, preventing invalid access during clustering
- Adds a test that covers the small-job case and verifies splits stay unset

### Impact
`✅ Fewer crashes on small job sets`
`✅ Safer performance scoring for sparse data`
`✅ More reliable strategy tuning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of small or uneven cluster results so performance calculations no longer fail when there are fewer than four usable groups.
  * Added a safeguard to avoid out-of-range errors during split generation, leaving splits unset when there isn’t enough data.
* **Tests**
  * Added coverage for the low-job-count case to verify splits stay empty when clustering produces too few groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->