### PR TITLE
修复回测重复下载数据问题，需重建问题涉及的数据表：

### DIFF
--- a/orm/compact.go
+++ b/orm/compact.go
@@ -107,6 +107,12 @@ func (s *compactState) getTableLock(table string) *sync.RWMutex {
 // MaybeCompact should be called after logical-delete writes.
 // It probabilistically triggers a compact check, guarded by per-table cooldown.
 func MaybeCompact(tableName string) {
+	// QuestDB compaction replaces a live WAL table via DROP/RENAME. Regular writers
+	// do not share the compaction lock, so that sequence can corrupt an active WAL.
+	// Keep logical deletes, but defer physical reclamation until it has a safe path.
+	if IsQuestDB {
+		return
+	}
 	if testing.Testing() {
 		return
 	}


### PR DESCRIPTION
RENAME TABLE sranges_q TO sranges_q_corrupt_20260711; RENAME TABLE ins_kline_q TO ins_kline_q_corrupt_20260711; CREATE TABLE ins_kline_q (...)
TIMESTAMP(ts) PARTITION BY DAY WAL
DEDUP UPSERT KEYS(sid, timeframe, ts);
CREATE TABLE ins_kline_q (...)
TIMESTAMP(ts) PARTITION BY DAY WAL
DEDUP UPSERT KEYS(sid, timeframe, ts);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled automatic compaction for QuestDB environments to prevent conflicts with concurrent writers.
  * Preserved existing compaction behavior for other supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->