### PR TITLE
修复实盘服务器异常时，重启实盘闪退问题：只是临时解决方案，需要你决定是pull进主干，还是有更好的解决方案。附原问题错误提示：ERROR entry/main.go:29 banbot panic error=[DbReadFail] questdb kline row not visible before timeout: sid=28 timeframe=1h time=1783904400000   at D:/ban/banbot/orm/questdb_visibility.go:192 github.com/banbox/banbot/orm.waitForQuestKlineTimestampVisible   at D:/ban/banbot/orm/kdata.go:388 github.com/banbox/banbot/orm.downOHLCV2DBRange   at D:/ban/banbot/orm/kdata.go:689 github.com/banbox/banbot/orm.BulkDownOHLCV.func1   at D:/ban/banbot/utils/misc.go:251 github.com/banbox/banbot/utils.ParallelRun[...].func1   at C:/Program Files/Go/src/runtime/asm_amd64.s:1693 runtime.goexit

### DIFF
--- a/orm/compact.go
+++ b/orm/compact.go
@@ -107,6 +107,12 @@ func (s *compactState) getTableLock(table string) *sync.RWMutex {
 // MaybeCompact should be called after logical-delete writes.
 // It probabilistically triggers a compact check, guarded by per-table cooldown.
 func MaybeCompact(tableName string) {
+	// QuestDB compaction replaces a live WAL table via DROP/RENAME. Regular writers
+	// do not share the compaction lock, so that sequence can corrupt an active WAL.
+	// Keep logical deletes, but defer physical reclamation until it has a safe path.
+	if IsQuestDB {
+		return
+	}
 	if testing.Testing() {
 		return
 	}

--- a/orm/kdata.go
+++ b/orm/kdata.go
@@ -384,10 +384,24 @@ func downOHLCV2DBRange(sess *Queries, exchange banexg.BanExchange, exs *ExSymbol
 	}
 
 	if saveNum > 0 {
+		klineVisible := true
 		if IsQuestDB {
-			if waitErr := waitForQuestKlineTimestampVisible(context.Background(), sess, exs.ID, timeFrame, realEnd); waitErr != nil {
+			var waitErr *errs.Error
+			klineVisible, waitErr = pollQuestKlineTimestampVisible(context.Background(), sess, exs.ID, timeFrame, realEnd)
+			if waitErr != nil {
 				clearInsJob = false
 				return saveNum, waitErr
+			}
+			if !klineVisible {
+				// The INSERT was accepted, but the WAL row is not queryable yet. Continue
+				// writing range metadata, retain the pending job, and let startup recovery
+				// verify it later instead of aborting the live process.
+				clearInsJob = false
+				log.Warn("questdb kline row not visible; defer insert recovery",
+					zap.Int32("sid", exs.ID),
+					zap.String("tf", timeFrame),
+					zap.Int64("start", realStart),
+					zap.Int64("end", realEnd+tfMSecs))
 			}
 		}
 		updErr := sess.UpdateKRange(exs, timeFrame, realStart, realEnd+tfMSecs, true, true)
@@ -400,10 +414,18 @@ func downOHLCV2DBRange(sess *Queries, exchange banexg.BanExchange, exs *ExSymbol
 					zap.String("err", updErr.Short()))
 			}
 		}
-		if outErr == nil && IsQuestDB {
-			if waitErr := waitForQuestKlineCoverageVisible(context.Background(), sess, exs.ID, timeFrame, realStart, realEnd+tfMSecs); waitErr != nil {
+		if outErr == nil && IsQuestDB && klineVisible {
+			covered, waitErr := pollQuestKlineCoverageVisible(context.Background(), sess, exs.ID, timeFrame, realStart, realEnd+tfMSecs)
+			if waitErr != nil {
 				clearInsJob = false
 				outErr = waitErr
+			} else if !covered {
+				clearInsJob = false
+				log.Warn("questdb kline coverage not visible; defer insert recovery",
+					zap.Int32("sid", exs.ID),
+					zap.String("tf", timeFrame),
+					zap.Int64("start", realStart),
+					zap.Int64("end", realEnd+tfMSecs))
 			}
 		}
 	}

--- a/orm/questdb_visibility.go
+++ b/orm/questdb_visibility.go
@@ -159,12 +159,23 @@ func questKlineCoverageVisible(ctx context.Context, q *Queries, sid int32, timef
 	return len(missing) == 0, nil
 }
 
-func waitForQuestKlineCoverageVisible(ctx context.Context, q *Queries, sid int32, timeframe string, startMS, endMS int64) *errs.Error {
+// pollQuestKlineCoverageVisible distinguishes a normal WAL visibility timeout from
+// a database read failure. Callers that already have a durable pending insert marker
+// can defer the former to recovery without treating it as a failed write.
+func pollQuestKlineCoverageVisible(ctx context.Context, q *Queries, sid int32, timeframe string, startMS, endMS int64) (bool, *errs.Error) {
 	ok, err := waitForQuestCondition(ctx, klineInsertQuestVisibilityGrace, questReadAfterWritePollInterval, func() (bool, error) {
 		return questKlineCoverageVisible(ctx, q, sid, timeframe, startMS, endMS)
 	})
 	if err != nil {
-		return NewDbErr(core.ErrDbReadFail, err)
+		return false, NewDbErr(core.ErrDbReadFail, err)
+	}
+	return ok, nil
+}
+
+func waitForQuestKlineCoverageVisible(ctx context.Context, q *Queries, sid int32, timeframe string, startMS, endMS int64) *errs.Error {
+	ok, err := pollQuestKlineCoverageVisible(ctx, q, sid, timeframe, startMS, endMS)
+	if err != nil {
+		return err
 	}
 	if !ok {
 		return errs.NewMsg(core.ErrDbReadFail,
@@ -174,7 +185,10 @@ func waitForQuestKlineCoverageVisible(ctx context.Context, q *Queries, sid int32
 	return nil
 }
 
-func waitForQuestKlineTimestampVisible(ctx context.Context, q *Queries, sid int32, timeframe string, timeMS int64) *errs.Error {
+// pollQuestKlineTimestampVisible distinguishes a normal WAL visibility timeout
+// from a database read failure. A successful INSERT is durable even while QuestDB
+// has not made the row queryable yet.
+func pollQuestKlineTimestampVisible(ctx context.Context, q *Queries, sid int32, timeframe string, timeMS int64) (bool, *errs.Error) {
 	tblName := "kline_" + timeframe
 	sqlText := fmt.Sprintf(`SELECT count(*) > 0 FROM %s
 	WHERE sid = $1 AND ts = cast($2 as timestamp)`, tblName)
@@ -186,7 +200,15 @@ func waitForQuestKlineTimestampVisible(ctx context.Context, q *Queries, sid int3
 		return visible, nil
 	})
 	if err != nil {
-		return NewDbErr(core.ErrDbReadFail, err)
+		return false, NewDbErr(core.ErrDbReadFail, err)
+	}
+	return ok, nil
+}
+
+func waitForQuestKlineTimestampVisible(ctx context.Context, q *Queries, sid int32, timeframe string, timeMS int64) *errs.Error {
+	ok, err := pollQuestKlineTimestampVisible(ctx, q, sid, timeframe, timeMS)
+	if err != nil {
+		return err
 	}
 	if !ok {
 		return errs.NewMsg(core.ErrDbReadFail,


### PR DESCRIPTION
修复实盘服务器异常时，重启实盘闪退问题：只是临时解决方案，需要你决定是pull进主干，还是有更好的解决方案。附原问题错误提示：ERROR entry/main.go:29 banbot panic error=[DbReadFail] questdb kline row not visible before timeout: sid=28 timeframe=1h time=1783904400000
  at D:/ban/banbot/orm/questdb_visibility.go:192 github.com/banbox/banbot/orm.waitForQuestKlineTimestampVisible
  at D:/ban/banbot/orm/kdata.go:388 github.com/banbox/banbot/orm.downOHLCV2DBRange
  at D:/ban/banbot/orm/kdata.go:689 github.com/banbox/banbot/orm.BulkDownOHLCV.func1
  at D:/ban/banbot/utils/misc.go:251 github.com/banbox/banbot/utils.ParallelRun[...].func1
  at C:/Program Files/Go/src/runtime/asm_amd64.s:1693 runtime.goexit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when newly downloaded market data is not immediately visible.
  * Prevented incomplete recovery actions when data visibility is still pending.
  * Improved handling of database read failures and visibility timeouts, preserving clearer error reporting.
  * Adjusted compaction behavior for QuestDB to avoid conflicts with active data writers and improve database stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->