### PR TITLE
fix(opt): guard empty KMeans clusters in groupByProfits to avoid slices.Min panic

### DIFF
--- a/opt/reports.go
+++ b/opt/reports.go
@@ -441,6 +441,14 @@ func (r *BTResult) groupByProfits(orders []*ormo.InOutOrder) {
 	res := utils.KMeansVals(rates, clsNum)
 	var grpTitles = make([]string, 0, len(res.Clusters))
 	for _, gp := range res.Clusters {
+		if len(gp.Items) == 0 {
+			// KMeansVals can emit empty clusters for degenerate (many-duplicate) inputs.
+			// No order maps to an empty cluster (res.RowGIds never references it), but a
+			// title slot must still exist so grpTitles stays index-aligned with the cluster
+			// ids used below via grpTitles[res.RowGIds[i]].
+			grpTitles = append(grpTitles, "")
+			continue
+		}
 		minPct := strconv.FormatFloat(slices.Min(gp.Items)*100, 'f', 2, 64)
 		maxPct := strconv.FormatFloat(slices.Max(gp.Items)*100, 'f', 2, 64)
 		grpTitles = append(grpTitles, fmt.Sprintf("%s ~ %s%%", minPct, maxPct))

--- a/opt/reports_test.go
+++ b/opt/reports_test.go
@@ -1,0 +1,40 @@
+package opt
+
+import (
+	"testing"
+
+	"github.com/banbox/banbot/orm/ormo"
+	"github.com/banbox/banbot/utils"
+)
+
+func TestGroupByProfitsHandlesEmptyKMeansClusters(t *testing.T) {
+	const orderCount = 10
+	orders := make([]*ormo.InOutOrder, orderCount)
+	rates := make([]float64, orderCount)
+	for i := range orders {
+		orders[i] = &ormo.InOutOrder{
+			IOrder: &ormo.IOrder{
+				ProfitRate: 0.01,
+				Profit:     1,
+				Leverage:   1,
+			},
+			Enter: &ormo.ExOrder{Average: 1, Filled: 1},
+		}
+		rates[i] = orders[i].ProfitRate
+	}
+
+	clusters := utils.KMeansVals(rates, 4)
+	hasEmptyCluster := false
+	for _, cluster := range clusters.Clusters {
+		hasEmptyCluster = hasEmptyCluster || len(cluster.Items) == 0
+	}
+	if !hasEmptyCluster {
+		t.Fatal("expected duplicate profit rates to produce an empty KMeans cluster")
+	}
+
+	result := &BTResult{}
+	result.groupByProfits(orders)
+	if len(result.ProfitGrps) != 1 {
+		t.Fatalf("profit groups = %d, want 1", len(result.ProfitGrps))
+	}
+}


### PR DESCRIPTION
## **User description**
## Summary

`BTResult.groupByProfits` panicked with `slices.Min: empty list` on backtests whose profit-rate distribution is degenerate (many duplicate values). This guards the empty-cluster case before calling `slices.Min` / `slices.Max`, so reporting no longer aborts the whole backtest.

## Motivation

`groupByProfits` (`opt/reports.go`) clusters order profit rates with `utils.KMeansVals` and, for each cluster, builds a title from `slices.Min(gp.Items)` / `slices.Max(gp.Items)`. When the input has many duplicate profit rates, `KMeansVals` can return clusters with empty `Items` (empty centers), and `slices.Min`/`slices.Max` on an empty slice panics. Because this runs inside `BTResult.Collect()`, one degenerate distribution aborts the entire backtest at reporting time.

Fixes #157.

## Fix

In the cluster loop, when a cluster has no items, append an empty placeholder title and continue instead of calling `slices.Min`/`slices.Max`. The placeholder is never displayed because orders only map to non-empty clusters via `grpTitles[res.RowGIds[i]]`, but keeping the slot preserves the index alignment between `grpTitles` and the cluster ids — dropping empty clusters would misalign that lookup.

## Testing

Added `TestGroupByProfitsHandlesEmptyKMeansClusters` to `opt/reports_test.go`: it builds orders with identical profit rates, asserts that `KMeansVals` indeed yields an empty cluster for that input, and then calls `groupByProfits` and asserts it completes without panicking. The test fails with the original `slices.Min: empty list` panic before this change and passes after it.

- `go test ./opt/` — passes.
- `go build ./opt/...` and `gofmt -l opt/reports.go` — clean.


___

## **CodeAnt-AI Description**
**Prevent backtests from crashing when profit clustering produces empty groups**

### What Changed
- Backtests no longer fail when profit-rate clustering returns an empty group for repeated or duplicate values
- Empty cluster slots are kept in place so profit-group labels still line up with the cluster IDs used later in reporting
- Added a test that reproduces this duplicate-profit case and verifies grouping completes without a panic

### Impact
`✅ Fewer backtest crashes`
`✅ Stable reporting with duplicate profit rates`
`✅ Clearer backtest output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profit-range reporting when clustering produces empty ranges.
  - Prevented failures during report generation for orders with identical profit-rate values.
  - Ensured orders are assigned to the correct profit group even when some ranges contain no items.

- **Tests**
  - Added coverage for reports containing empty KMeans clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->