### PR TITLE
fix(cli): allow Explorer launches to open the web UI

### DIFF
--- a/entry/main.go
+++ b/entry/main.go
@@ -39,6 +39,7 @@ func RunCmd() {
 
 	installSignalHandler()
 	deadlock.Opts.Disable = true
+	cobra.MousetrapHelpText = ""
 	if err := Execute(os.Args[1:]); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		core.RunExitCalls()


### PR DESCRIPTION
## Summary
- Disable Cobra's Windows Explorer mousetrap prompt in `entry.RunCmd`.
- Preserve Banbot's existing no-argument Web UI launch path when `bot.exe` is opened from Explorer.

## Testing
- Not run (source-only compatibility change; no binary build requested).