### PR TITLE
fix(live): reconcile pending exits before no-match close

### DIFF
--- a/biz/odmgr_live.go
+++ b/biz/odmgr_live.go
@@ -213,6 +213,26 @@ func (o *LiveOrderMgr) SyncLocalOrders() ([]*ormo.InOutOrder, *errs.Error) {
 
 			// 如果本地订单量大于实际持仓量,需要关闭部分订单
 			if localAmt > posAmt*1.02 {
+				// A position snapshot can arrive before the private fill stream. Reconcile
+				// submitted exits by their own exchange IDs before using the aggregate
+				// no-match fallback, so a sibling order is never chosen for that fill.
+				changed, pending := o.reconcilePendingExitOrders(curOds)
+				if changed {
+					localAmt = 0
+					for _, od := range curOds {
+						localAmt += od.HoldAmount()
+					}
+				}
+				if localAmt <= posAmt*1.02 {
+					continue
+				}
+				if pending {
+					log.Warn("defer local position mismatch while exit order is pending",
+						zap.String("acc", o.Account), zap.String("pair", symbol), zap.Bool("short", isShort),
+						zap.Float64("localAmt", localAmt), zap.Float64("exgAmt", posAmt))
+					continue
+				}
+
 				// 按数量降序排序
 				sort.Slice(curOds, func(i, j int) bool {
 					amtI := curOds[i].HoldAmount()
@@ -258,6 +278,65 @@ func (o *LiveOrderMgr) SyncLocalOrders() ([]*ormo.InOutOrder, *errs.Error) {
 		}
 	}
 	return closedList, nil
+}
+
+// reconcilePendingExitOrders refreshes submitted exits by their exchange order IDs.
+// It returns pending=true when an exit cannot yet be authoritatively resolved; callers
+// must then avoid attributing a position delta to another local order.
+func (o *LiveOrderMgr) reconcilePendingExitOrders(ods []*ormo.InOutOrder) (changed, pending bool) {
+	for _, od := range ods {
+		if od == nil {
+			continue
+		}
+		lock := od.Lock()
+		exit := od.Exit
+		if exit == nil || exit.OrderID == "" || exit.Status == ormo.OdStatusClosed ||
+			od.Status >= ormo.InOutStatusFullExit {
+			lock.Unlock()
+			continue
+		}
+		orderID, symbol, odKey := exit.OrderID, od.Symbol, od.Key()
+		lock.Unlock()
+
+		res, err := exg.Default.FetchOrder(symbol, orderID, map[string]interface{}{
+			banexg.ParamAccount: o.Account,
+		})
+		if err != nil {
+			pending = true
+			log.Warn("reconcile pending exit fetch fail", zap.String("acc", o.Account),
+				zap.String("key", odKey), zap.String("orderId", orderID), zap.Error(err))
+			continue
+		}
+		if res == nil || res.ID != orderID {
+			pending = true
+			log.Warn("reconcile pending exit invalid response", zap.String("acc", o.Account),
+				zap.String("key", odKey), zap.String("orderId", orderID))
+			continue
+		}
+
+		lock = od.Lock()
+		exit = od.Exit
+		if exit == nil || exit.OrderID != orderID || exit.Status == ormo.OdStatusClosed ||
+			od.Status >= ormo.InOutStatusFullExit {
+			lock.Unlock()
+			continue
+		}
+		beforeFilled, beforeStatus := exit.Filled, od.Status
+		err = o.updateOdByExgRes(od, false, res)
+		changed = changed || exit.Filled > beforeFilled+AmtDust || od.Status != beforeStatus
+		unresolved := od.Status < ormo.InOutStatusFullExit && exit.Status != ormo.OdStatusClosed
+		lock.Unlock()
+		if err != nil {
+			pending = true
+			log.Error("reconcile pending exit apply fail", zap.String("acc", o.Account),
+				zap.String("key", odKey), zap.String("orderId", orderID), zap.Error(err))
+			continue
+		}
+		if unresolved {
+			pending = true
+		}
+	}
+	return changed, pending
 }
 
 /*

--- a/biz/odmgr_live_test.go
+++ b/biz/odmgr_live_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/banbox/banbot/btime"
+	"github.com/banbox/banbot/com"
 	"github.com/banbox/banbot/config"
 	"github.com/banbox/banbot/core"
 	"github.com/banbox/banbot/exg"
@@ -39,6 +40,7 @@ type issue138Exchange struct {
 	cancelOrder     func(id, symbol string, params map[string]interface{}) (*banexg.Order, *errs.Error)
 	fetchOrder      func(symbol, id string, params map[string]interface{}) (*banexg.Order, *errs.Error)
 	fetchOrders     func(symbol string, since int64, limit int, params map[string]interface{}) ([]*banexg.Order, *errs.Error)
+	fetchPositions  func(symbols []string, params map[string]interface{}) ([]*banexg.Position, *errs.Error)
 	createOrder     func(symbol, odType, side string, amount, price float64, params map[string]interface{}) (*banexg.Order, *errs.Error)
 	fetchOpenOrders func(symbol string, since int64, limit int, params map[string]interface{}) ([]*banexg.Order, *errs.Error)
 	fetchTickers    func(symbols []string, params map[string]interface{}) ([]*banexg.Ticker, *errs.Error)
@@ -54,6 +56,13 @@ func (e *issue138Exchange) FetchOrder(symbol, id string, params map[string]inter
 
 func (e *issue138Exchange) FetchOrders(symbol string, since int64, limit int, params map[string]interface{}) ([]*banexg.Order, *errs.Error) {
 	return e.fetchOrders(symbol, since, limit, params)
+}
+
+func (e *issue138Exchange) FetchAccountPositions(symbols []string, params map[string]interface{}) ([]*banexg.Position, *errs.Error) {
+	if e.fetchPositions == nil {
+		return nil, nil
+	}
+	return e.fetchPositions(symbols, params)
 }
 
 func (e *issue138Exchange) CreateOrder(symbol, odType, side string, amount, price float64, params map[string]interface{}) (*banexg.Order, *errs.Error) {
@@ -1367,6 +1376,159 @@ func TestWatchMyTradesStopsDuringRetryDelay(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("WatchMyTrades calls = %d, want 1", calls)
+	}
+}
+
+func withIsolatedOrderState(t *testing.T) {
+	t.Helper()
+	backup := ormo.BackupVars()
+	ormo.ResetVars()
+	t.Cleanup(func() { ormo.RestoreVars(backup) })
+}
+func makeEnteredOrder(id int64, symbol, enterID string, amount float64) *ormo.InOutOrder {
+	od := issue138Order(enterID)
+	od.ID = id
+	od.EnterAt = id
+	od.Symbol = symbol
+	od.Enter.Symbol = symbol
+	od.Status = ormo.InOutStatusFullEnter
+	od.Enter.Filled = amount
+	od.Enter.Amount = amount
+	od.Enter.Average = 100
+	od.Enter.Status = ormo.OdStatusClosed
+	return od
+}
+
+func TestSyncLocalOrdersReconcilesSubmittedExitBeforeNoMatch(t *testing.T) {
+	withIsolatedOrderState(t)
+	const account = "exit-reconcile"
+	const symbol = "EXITREC/USDT:USDT"
+	target := makeEnteredOrder(2101, symbol, "target-entry", 2)
+	target.Exit = &ormo.ExOrder{
+		OrderID: "target-exit", Symbol: symbol, Side: banexg.OdSideSell,
+		OrderType: banexg.OdTypeMarket, Amount: 2, Status: ormo.OdStatusInit,
+	}
+	sibling := makeEnteredOrder(2102, symbol, "sibling-entry", 10)
+	fetchCalls := 0
+	withIssue138Exchange(t, &issue138Exchange{
+		fetchOrder: func(gotSymbol, id string, _ map[string]interface{}) (*banexg.Order, *errs.Error) {
+			fetchCalls++
+			if gotSymbol != symbol || id != "target-exit" {
+				t.Fatalf("unexpected FetchOrder(%q, %q)", gotSymbol, id)
+			}
+			return &banexg.Order{
+				ID: id, Symbol: symbol, Side: banexg.OdSideSell, Type: banexg.OdTypeMarket,
+				Status: banexg.OdStatusFilled, Amount: 2, Filled: 2, Average: 99,
+				LastUpdateTimestamp: btime.UTCStamp(),
+			}, nil
+		},
+		fetchPositions: func([]string, map[string]interface{}) ([]*banexg.Position, *errs.Error) {
+			return []*banexg.Position{{Symbol: symbol, Side: banexg.PosSideLong, Contracts: 10}}, nil
+		},
+	})
+	mgr := newLiveOrderMgr(account, func(*ormo.InOutOrder, bool) {})
+	openOds, lock := ormo.GetOpenODs(account)
+	lock.Lock()
+	openOds[target.ID] = target
+	openOds[sibling.ID] = sibling
+	lock.Unlock()
+	t.Cleanup(func() {
+		lock.Lock()
+		delete(openOds, target.ID)
+		delete(openOds, sibling.ID)
+		lock.Unlock()
+	})
+
+	closed, err := mgr.SyncLocalOrders()
+	if err != nil {
+		t.Fatalf("SyncLocalOrders: %v", err)
+	}
+	if fetchCalls != 1 {
+		t.Fatalf("FetchOrder calls = %d, want 1", fetchCalls)
+	}
+	if len(closed) != 0 {
+		t.Fatalf("no_match closed orders = %d, want 0", len(closed))
+	}
+	if target.Status != ormo.InOutStatusFullExit || target.Exit == nil || target.Exit.Filled != 2 {
+		t.Fatalf("submitted exit was not reconciled to its own order: status=%d exit=%+v", target.Status, target.Exit)
+	}
+	if sibling.Status != ormo.InOutStatusFullEnter || sibling.Exit != nil || sibling.HoldAmount() != 10 {
+		t.Fatalf("submitted exit mutated sibling: status=%d exit=%+v hold=%v", sibling.Status, sibling.Exit, sibling.HoldAmount())
+	}
+}
+
+func TestSyncLocalOrdersDefersNoMatchWhileExitIsUnresolved(t *testing.T) {
+	withIsolatedOrderState(t)
+	const account = "exit-pending"
+	const symbol = "EXITPENDING/USDT:USDT"
+	target := makeEnteredOrder(2201, symbol, "target-entry", 2)
+	target.Exit = &ormo.ExOrder{
+		OrderID: "target-exit", Symbol: symbol, Side: banexg.OdSideSell,
+		OrderType: banexg.OdTypeMarket, Amount: 2, Status: ormo.OdStatusInit,
+	}
+	sibling := makeEnteredOrder(2202, symbol, "sibling-entry", 10)
+	withIssue138Exchange(t, &issue138Exchange{
+		fetchOrder: func(string, string, map[string]interface{}) (*banexg.Order, *errs.Error) {
+			return &banexg.Order{
+				ID: "target-exit", Symbol: symbol, Side: banexg.OdSideSell, Type: banexg.OdTypeMarket,
+				Status: banexg.OdStatusOpen, Amount: 2, Filled: 0, LastUpdateTimestamp: btime.UTCStamp(),
+			}, nil
+		},
+		fetchPositions: func([]string, map[string]interface{}) ([]*banexg.Position, *errs.Error) {
+			return []*banexg.Position{{Symbol: symbol, Side: banexg.PosSideLong, Contracts: 10}}, nil
+		},
+	})
+	mgr := newLiveOrderMgr(account, func(*ormo.InOutOrder, bool) {})
+	openOds, lock := ormo.GetOpenODs(account)
+	lock.Lock()
+	openOds[target.ID] = target
+	openOds[sibling.ID] = sibling
+	lock.Unlock()
+	t.Cleanup(func() {
+		lock.Lock()
+		delete(openOds, target.ID)
+		delete(openOds, sibling.ID)
+		lock.Unlock()
+	})
+
+	closed, err := mgr.SyncLocalOrders()
+	if err != nil {
+		t.Fatalf("SyncLocalOrders: %v", err)
+	}
+	if len(closed) != 0 || target.Status != ormo.InOutStatusFullEnter || sibling.Status != ormo.InOutStatusFullEnter || sibling.Exit != nil {
+		t.Fatalf("unresolved submitted exit allowed a no_match close: closed=%d target=%d sibling=%d siblingExit=%+v",
+			len(closed), target.Status, sibling.Status, sibling.Exit)
+	}
+}
+
+func TestSyncLocalOrdersKeepsNoMatchFallbackWithoutSubmittedExit(t *testing.T) {
+	withIsolatedOrderState(t)
+	const account = "exit-fallback"
+	const symbol = "EXITFALLBACK/USDT:USDT"
+	od := makeEnteredOrder(2301, symbol, "entry", 2)
+	com.SetPrice(symbol, 100, 100)
+	withIssue138Exchange(t, &issue138Exchange{
+		fetchPositions: func([]string, map[string]interface{}) ([]*banexg.Position, *errs.Error) {
+			return nil, nil
+		},
+	})
+	mgr := newLiveOrderMgr(account, func(*ormo.InOutOrder, bool) {})
+	openOds, lock := ormo.GetOpenODs(account)
+	lock.Lock()
+	openOds[od.ID] = od
+	lock.Unlock()
+	t.Cleanup(func() {
+		lock.Lock()
+		delete(openOds, od.ID)
+		lock.Unlock()
+	})
+
+	closed, err := mgr.SyncLocalOrders()
+	if err != nil {
+		t.Fatalf("SyncLocalOrders: %v", err)
+	}
+	if len(closed) != 1 || closed[0] != od || od.ExitTag != core.ExitTagNoMatch || od.Status != ormo.InOutStatusFullExit {
+		t.Fatalf("legacy no_match fallback changed: closed=%+v status=%d tag=%q", closed, od.Status, od.ExitTag)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reconcile submitted exit orders by their exchange order IDs before applying the aggregate local `no_match` fallback.
- Defer that fallback while a submitted exit is still unresolved, preventing a position delta from being attributed to a sibling order.
- Preserve the existing fallback when no submitted exit is pending.

## Tests
- `go test ./biz -run 'TestSyncLocalOrders(ReconcilesSubmittedExitBeforeNoMatch|DefersNoMatchWhileExitIsUnresolved|KeepsNoMatchFallbackWithoutSubmittedExit)$' -count=1`
